### PR TITLE
Remove the OTP check in the response

### DIFF
--- a/ycloud.go
+++ b/ycloud.go
@@ -306,6 +306,11 @@ func (y *YubiClient) Verify(req *VerifyRequest) (*VerifyResponse, error) {
 		return nil, err
 	}
 
+	// Invalid values don't return the Nonce
+	if response.Nonce == "" && response.Status.IsError() {
+		return response, nil
+	}
+
 	if response.Nonce != req.Nonce {
 		return nil, errors.New("response Nonce does not match")
 	}

--- a/ycloud.go
+++ b/ycloud.go
@@ -306,9 +306,6 @@ func (y *YubiClient) Verify(req *VerifyRequest) (*VerifyResponse, error) {
 		return nil, err
 	}
 
-	if response.OTP != req.OTP {
-		return nil, errors.New("response OTP does not match")
-	}
 	if response.Nonce != req.Nonce {
 		return nil, errors.New("response Nonce does not match")
 	}


### PR DESCRIPTION
The nonce check should be sufficient to verify that the response matches
the request. Alternative keyboard layouts are supported by the Yubikey
validation api, but the OTP value that is returned is normalized into
the QUERTY keyboard character set. The OTP equality check prevents
dvorak users from validating their yubikey.