### PR TITLE
Simplified checks

### DIFF
--- a/ycloud.go
+++ b/ycloud.go
@@ -236,7 +236,7 @@ func (y *YubiClient) responseFromBody(body []byte) (*VerifyResponse, error) {
 		return nil, fmt.Errorf("error parsing response timestamp: %s", err)
 	}
 
-	r.Status = statusFromString(string(m["status"]))
+	r.Status = statusFromString(m["status"])
 	if sl, ok := m["sl"]; ok {
 		r.SL, err = strconv.Atoi(sl)
 		if err != nil {

--- a/ycloud.go
+++ b/ycloud.go
@@ -212,7 +212,7 @@ func (y *YubiClient) responseFromBody(body []byte) (*VerifyResponse, error) {
 	for scanner.Scan() {
 		l := scanner.Bytes()
 		s := bytes.SplitN(l, []byte{'='}, 2)
-		if s == nil || len(s) == 0 || len(s) != 2 {
+		if len(s) != 2 {
 			continue
 		}
 		m[string(s[0])] = string(s[1])

--- a/ycloud.go
+++ b/ycloud.go
@@ -120,7 +120,7 @@ func (v *VerifyRequest) toValues() url.Values {
 func isValidResponseHash(m map[string]string, key []byte) bool {
 
 	// if we have no API key, or no hash was provided, then it's valid
-	if key == nil || len(key) == 0 || m["h"] == "" {
+	if len(key) == 0 || m["h"] == "" {
 		return true
 	}
 


### PR DESCRIPTION
Hi, thought this may simplify a little bit.
Please let me know if I am wrong.

1) `len()` of nil slice is 0, so I guess it is safe to do this simplification.
2) `bytes.SplitN()` will always return slice, as I can see: https://play.golang.org/p/mjBHoF_k5a

I really want to make constants camel case but it may break backwards compatibility I guess.
Cheers.